### PR TITLE
 "KeepAwake.activate" static method has been deprecated

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -7,6 +7,5 @@
    :init-fn example.app/init
    :output-dir "app"
    :compiler-options {:infer-externs :auto}
-   :devtools {:autoload true
-              :preloads [shadow.expo.keep-awake]}}}}
+   :devtools {:autoload true}}}}
 


### PR DESCRIPTION
Expo.io moved the API to separate packages as discuted here https://github.com/thheller/shadow-cljs/issues/513