### PR TITLE
[fix #7] document "known good" toolchain configs in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ A production build invloves first asking shadow-cljs to build a relase, then to 
 
 If you get complaints about [Module HMRClient is not a registered callable module](https://github.com/expo/expo/issues/916)*, you probably have **Hot reloading** enabled. Disable it and try again.
 
+## "Known good" toolchain configurations
+
+This repository provides a baseline setup for a React Native application. However newcomers may still have problems getting up in running "in 3 minutes" because of obscure dependencies on supporting tools such as the Java and Node runtimes. So while we can't definitively show every viable configuration, we can at least maintain what's known to work, especially when dependencies are bumped.
+
+Expo SDK          | 35
+----------------- | ------------------
+clojure           | 1.10.1
+clojurescript     | 1.10.520
+expo-cli          | 3.4.1
+expo              | 35.0.0
+jdk               | openjdk 1.8.0_222
+node              | 10.17.0
+re-frame          | 0.11.0-rc2
+react             | 16.9.0
+reagent           | 0.9.0-rc2
+shadow-cljs (cli) | 2.8.69
+shadow-cljs (jar) | 2.8.69
+yarn              | 1.19.1
+
+When in doubt, a script is provided in this repo (`etc/toolchain-report`) to query what versions you have. This script is NOT needed for app development, building, or releasing, but may come in handy if you're having trouble getting up and running. `toolchain-report` requires `joker`, a portable and fast dialect of clojure implemented in go. See [the joker repo on github](https://github.com/candid82/joker) for installation instructions.
+
 ## Some notes from Thomas Heller
 
 (This project is built from this example of his: https://github.com/thheller/reagent-expo)

--- a/etc/toolchain-report
+++ b/etc/toolchain-report
@@ -1,0 +1,114 @@
+#!/Usr/bin/env joker
+
+;; Usage: toolchain-report
+;; 
+;; This tool queries a set of defined packages in your "toolchain" and
+;; reports the versions of those packages in a map.  There are no
+;; command line flags or options for this script.
+
+(ns main
+  (:require [joker.os :as os]))
+
+
+;; The "toolchain" is defined as a vector of maps that define how to
+;; query for version. We expect every tool has some command line flag
+;; that writes the version info to stdout or stderr, but each tool
+;; might format that output in some unique way. Therefore we specify a
+;; regular expression pattern that will be used to extract the version
+;; from the output.
+;;
+;; Easiest to show an example:
+;; 
+;;  {
+;;    :key :yarn                ; each tool has a unique key
+;;    :cmd ["yarn" "-v"]        ; executing this prints the version
+;;    :pattern #"(.*)\n"        ; this regexp extracts the version #
+;;    :output :out              ; :out = stdout, :err = stderr
+;;  }
+;;
+;; The default is to grab everything from stdout up to the first
+;; newline '\n', so our example can be shortened:
+;;
+;;  {:key :yarn :cmd ["yarn" "-v"]}
+;;
+
+(def toolchain
+  [
+;; operating system
+   {:key :os-name
+    :cmd ["clojure" "-e" "(System/getProperty \"os.name\")"]
+    :pattern #"\"(.*)\""}
+   {:key :os-version
+    :cmd ["clojure" "-e" "(System/getProperty \"os.version\")"]
+    :pattern #"\"(.*)\""}
+   {:key :todays-date
+    :cmd ["clojure" "-e" "(.toString (java.time.LocalDate/now))"]}
+
+;; clojure/clojurescript tools
+   {:key :clojure
+    :cmd ["clj" "-Stree"]
+    :pattern #"org.clojure/clojure\s+(.*)\n"}
+   {:key :clojurescript
+    :cmd ["clj" "-Stree"]
+    :pattern #"org.clojure/clojurescript\s+(.*)\n"}
+   {:key :shadow-cljs-jar
+    :cmd ["shadow-cljs" "info"]
+    :pattern #"jar:\s+(.*)\n"}
+   {:key :shadow-cljs-cli
+    :cmd ["shadow-cljs" "info"]
+    :pattern #"cli:\s+(.*)\n"}
+
+;; react native toolchain
+   {:key :expo-cli :cmd ["expo-cli" "-V"]}
+
+;; javascript tools
+   {:key :node :cmd ["node" "-v"]}
+   {:key :yarn :cmd ["yarn" "-v"]}
+
+;; libraries / packages
+   {:key :expo-js
+    :cmd ["yarn" "list"]
+    :pattern #"\s+expo@(.*)\n"}
+   {:key :react
+    :cmd ["yarn" "list"]
+    :pattern #"\s+react@(.*)\n"}
+   {:key :reagent
+    :cmd ["clj" "-Stree"]
+    :pattern #"reagent/reagent\s+(.*)\n"}
+   {:key :re-frame
+    :cmd ["clj" "-Stree"]
+    :pattern #"re-frame/re-frame\s+(.*)\n"}
+
+;; java jdk
+   {:key :jdk-vendor
+    :cmd ["java" "-version"]
+    :output :err
+    :pattern #"(.*)\s+version"}
+   {:key :jdk-version
+    :cmd ["java" "-version"]
+    :output :err
+    :pattern #"version\s+\"(.*)\"\n"}
+])
+
+(def sh-memoized (memoize #(apply os/sh %)))
+
+(defn check [{:keys [key cmd output pattern]
+              :or {output :out pattern #"(.*)\n"}}]
+  (let [result (try (sh-memoized cmd)
+                    (catch Error e {:success nil}))]
+    (if (:success result)
+      {key (-> (re-find pattern (output result))
+               (get 1))}
+      {key nil})))
+
+(defn print-sorted-keys [m]
+  ;; hack because joker doesn't provide sorted-map
+  (println "{")
+  (doseq [k (sort (keys m))]
+    (printf "  %s \"%s\"\n" k (k m)))
+  (println "}"))
+
+;; run all queries and print the result
+(print-sorted-keys (->> (map check toolchain)
+                        (apply merge)))
+


### PR DESCRIPTION
This pull request adds a table of tool versions into the README so that, at least, newcomers can refer to that table when they're having trouble getting their project up and running (as I did).

Also provided is an optional convenience script `etc/toolchain-report` written in `joker` that performs the steps to query the versions of all these things.  The idea here is that users can use that tool before reporting issues with this repo.

I chose joker for this script as it's a lightweight dialect of clojure that is portable and fast, and also because *not* using clojurescript or clojure meant I wasn't going to be putting extra dependencies into the project's own `deps.edn` or `package.json`. 