### PR TITLE
Bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,52 @@ Open the project in VS Code. Then:
    1. Select the project type `shadow-cljs`.
    1. Select to start the `:app` build.
    1. Wait for shadow to build the project.
-1. Then **Start build task**. This will start Expo and the Metro builder. Wait for it to fire up Expo DevTools in your browser.
+1. Then **Start build task**. This will start Expo and the Metro
+   builder. Wait for it to fire up Expo DevTools in your browser.
    1. Start the app on your phone or in a simulator or in browser.
-   1. In the Expo settings for your app (shake or force touch with two fingers), disable Live Reloadinhg and Hot Reloading. (Don't worry, shadow-cljs will take care of hot reloading for you, in the most beautiful way.)
+   1. In the Expo settings for your app (shake or force touch with two
+      fingers), disable Live Reloadinhg and Hot Reloading. (Don't
+      worry, shadow-cljs will take care of hot reloading for you, in
+      the most beautiful way.)
 1. When the app is running in your phone/simulator the Calva CLJS REPL can be used.
 1. Hack away!
+
+## Using Emacs with CIDER
+
+Open Emacs and a bash shell:
+
+1. In the shell, execute `npm install -g expo-cli shadow-cljs`
+1. Then `yarn` and wait for it to finish.
+1. Then run `shadow-cljs compile :app` to perform an initial build of the app.
+1. In Emacs open one of the files in the project (`deps.edn` is fine)
+1. From that buffer, do `cider-jack-in-clojurescript` [C-c M-J] to
+   launch a REPL. Follow the series of interactive prompts in the
+   minibuffer:
+   1. select `shadow-cljs` as the command to launch
+   1. select `shadow` as the repl type
+   1. select `:app` as the build to connect
+   1. and optionally answer `y` or `n` to the final question about
+      opening the `shadow-cljs` UI in a browser.
+   At this point `shadow-cljs` will be watching the project folder and
+   running new builds of the app if any files are changed. You'll also
+   have a REPL prompt, *however the REPL doesn't work because it isn't
+   connected to anything. The app isn't running yet.*
+1. In a shell run `yarn ios` (same as `expo start -i`). This starts
+   the Metro bundler, perform the bundling, launch the iPhone
+   simulator, and transmit the bundled app. Be patient at this step as
+   it can take many seconds to complete. When the app is finally
+   running expo will display the message:
+   
+       WebSocket connected!
+       REPL init successful
+       
+1. Once you see that the REPL is initalized, you can return to Emacs
+   and confirm the REPL is connected and functional:
+   ``` clojure
+   cljs.user> (js/alert "hello world!")
+   ```   
+   Which should pop-up a modal alert in the simulator, confirming the
+   app is running and the REPL is connected end to end.
 
 ## Or the Command line
 ```sh

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ jdk               | openjdk 1.8.0_222 | openjdk 1.8.0_222
 node              | 10.17.0           | 10.17.0
 re-frame          | 0.11.0-rc2        | **0.11.0-rc3**
 react             | 16.9.0            | 16.9.0
+react-native      | 0.59.8            | 0.59.8
 reagent           | 0.9.0-rc2         | **0.9.0-rc3**
 shadow-cljs (cli) | 2.8.69            | **2.8.78**
 shadow-cljs (jar) | 2.8.69            | **2.8.78**

--- a/README.md
+++ b/README.md
@@ -79,20 +79,20 @@ If you get complaints about [Module HMRClient is not a registered callable modul
 
 This repository provides a baseline setup for a React Native application. However newcomers may still have problems getting up in running "in 3 minutes" because of obscure dependencies on supporting tools such as the Java and Node runtimes. So while we can't definitively show every viable configuration, we can at least maintain what's known to work, especially when dependencies are bumped.
 
-Expo SDK          | 35
------------------ | ------------------
-clojure           | 1.10.1
-clojurescript     | 1.10.520
-expo-cli          | 3.4.1
-expo              | 35.0.0
-jdk               | openjdk 1.8.0_222
-node              | 10.17.0
-re-frame          | 0.11.0-rc2
-react             | 16.9.0
-reagent           | 0.9.0-rc2
-shadow-cljs (cli) | 2.8.69
-shadow-cljs (jar) | 2.8.69
-yarn              | 1.19.1
+Expo SDK          | 35                | 35
+----------------- | ----------------- | -----------------
+clojure           | 1.10.1            | 1.10.1
+clojurescript     | 1.10.520          | **1.10.597**
+expo-cli          | 3.4.1             | **3.9.1**
+expo              | 35.0.0            | 35.0.0
+jdk               | openjdk 1.8.0_222 | openjdk 1.8.0_222
+node              | 10.17.0           | 10.17.0
+re-frame          | 0.11.0-rc2        | **0.11.0-rc3**
+react             | 16.9.0            | 16.9.0
+reagent           | 0.9.0-rc2         | **0.9.0-rc3**
+shadow-cljs (cli) | 2.8.69            | **2.8.78**
+shadow-cljs (jar) | 2.8.69            | **2.8.78**
+yarn              | 1.19.1            | 1.19.1
 
 When in doubt, a script is provided in this repo (`etc/toolchain-report`) to query what versions you have. This script is NOT needed for app development, building, or releasing, but may come in handy if you're having trouble getting up and running. `toolchain-report` requires `joker`, a portable and fast dialect of clojure implemented in go. See [the joker repo on github](https://github.com/candid82/joker) for installation instructions.
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,11 +2,8 @@
 {:paths ["src/main"
          "src/test"]
 
- :deps {reagent {:mvn/version "0.9.0-rc2"}
-        re-frame {:mvn/version "0.11.0-rc2"}
-        thheller/shadow-cljs {:mvn/version "2.8.67"}}
+ :deps {reagent {:mvn/version "0.9.0-rc3"}
+        re-frame {:mvn/version "0.11.0-rc3"}
+        thheller/shadow-cljs {:mvn/version "2.8.78"}}
 
- :aliases {:dev {:extra-paths ["src/test" "src/dev"]
-                 ;:extra-deps {reagent {:mvn/version "0.8.1"}}
-                 }}}
-
+ :aliases {:dev {:extra-paths ["src/test" "src/dev"]}}}

--- a/etc/toolchain-report
+++ b/etc/toolchain-report
@@ -72,6 +72,9 @@
    {:key :react
     :cmd ["yarn" "list"]
     :pattern #"\s+react@(.*)\n"}
+   {:key :react-native
+    :cmd ["yarn" "list"]
+    :pattern #"\s+react-native@(.*)\n"}
    {:key :reagent
     :cmd ["clj" "-Stree"]
     :pattern #"reagent/reagent\s+(.*)\n"}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "babel-preset-expo": "^7.1.0",
-    "shadow-cljs": "^2.8.67"
+    "shadow-cljs": "^2.8.78"
   },
   "private": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4733,10 +4733,10 @@ shadow-cljs-jar@1.3.1:
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.1.tgz#a5f8ab7664b40e11345837e4c6bce8e0ac9b2cc3"
   integrity sha512-IJSm4Gfu/wWDsOQ0wNrSxuaGdjzsd78us+3bop3cpWsoO2Igdu6VIBItYrZHRRBKl5LIZKXfnSh/2eWG3C1EFw==
 
-shadow-cljs@^2.8.67:
-  version "2.8.67"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.8.67.tgz#73f38e7a98e00a3945200e9fcb3060eb31db7c71"
-  integrity sha512-E7IQ3R7SOu9q664504rv7ZNIDuyctJGKVTthCPVuN9phCLlFs8csKLBk2J8fYfGh5xdjN9FwZdYchYuQkAtnSw==
+shadow-cljs@^2.8.78:
+  version "2.8.80"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.8.80.tgz#6e8d30a52d71afafef4f442346a66683601b4ac3"
+  integrity sha512-NoiIJJTlrkOGAwwgpwUuAVaew1pAcyHA9bT4XoU4ZSmUtJYInH6qYcmvStuZdDced7bJgRO7xvwOjYmJBPjbVg==
   dependencies:
     mkdirp "^0.5.1"
     node-libs-browser "^2.0.0"


### PR DESCRIPTION
Bump dependencies for `shadow-cljs`, `react` and `re-frame`.
Also add instructions to get up and running with Emacs & CIDER.