### PR TITLE
fix expo web start failure

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,6 +4,6 @@
 
  :deps {reagent {:mvn/version "0.9.0-rc3"}
         re-frame {:mvn/version "0.11.0-rc3"}
-        thheller/shadow-cljs {:mvn/version "2.8.78"}}
+        thheller/shadow-cljs {:mvn/version "2.8.81"}}
 
  :aliases {:dev {:extra-paths ["src/test" "src/dev"]}}}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "babel-preset-expo": "^7.1.0",
-    "shadow-cljs": "^2.8.78"
+    "shadow-cljs": "^2.8.81"
   },
   "private": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4733,10 +4733,10 @@ shadow-cljs-jar@1.3.1:
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.1.tgz#a5f8ab7664b40e11345837e4c6bce8e0ac9b2cc3"
   integrity sha512-IJSm4Gfu/wWDsOQ0wNrSxuaGdjzsd78us+3bop3cpWsoO2Igdu6VIBItYrZHRRBKl5LIZKXfnSh/2eWG3C1EFw==
 
-shadow-cljs@^2.8.78:
-  version "2.8.80"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.8.80.tgz#6e8d30a52d71afafef4f442346a66683601b4ac3"
-  integrity sha512-NoiIJJTlrkOGAwwgpwUuAVaew1pAcyHA9bT4XoU4ZSmUtJYInH6qYcmvStuZdDced7bJgRO7xvwOjYmJBPjbVg==
+shadow-cljs@^2.8.81:
+  version "2.8.81"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.8.81.tgz#d4f28313ef3d0023a9d7b9a0891ee0e124f0cfb8"
+  integrity sha512-ux+S7yB2isXxna8/BHRkkp80C6fXPwVrKnDd0SfTbLgjUE9TMjqHCgsO0jLejw/cjjAzAvyG4uVLyK60NxIwEg==
   dependencies:
     mkdirp "^0.5.1"
     node-libs-browser "^2.0.0"


### PR DESCRIPTION
update dependencies to shadow `2.8.81` , closes #11 