### PR TITLE
Update project to make eas build work with ios and android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,10 @@ out/
 pom.xml
 .idea/
 *.iml
-app/
+app/*
+# Include this file to make EAS Build work.
+# See https://github.com/expo/fyi/blob/master/eas-build-archive.md for details and another option.
+!app/index.js
 .cpcache
 /web-build
 .calva/output-window/

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The steps below provide an example of using EAS Build to build an apk file to ru
 
 0. Install the latest EAS CLI by running `npm install -g eas-cli`
 0. Log into your Expo account
-0. Configure EAS Build in your project with `eas configure:build`. When prompted, select Android for the platform.
+0. Configure EAS Build in your project with `eas build:configure`. When prompted, select Android for the platform.
 0. Make your eas.json file contents look like this:
    ```json
    {
@@ -178,6 +178,7 @@ The steps below provide an example of using EAS Build to build an apk file to ru
      }
    }
    ```
+0. Stop the shadow-cljs watch process if it's running. Run `npm run release`.
 0. Run `eas build --profile=development --platform=android`
 0. Navigate to the URL given by the command to monitor the build. When it completes, download the apk and install it on your device or emulator.
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "web": "npx expo start --web",
     "web-only": "npx expo start --web-only",
     "release": "npx shadow-cljs release app",
-    "eject": "npx expo eject",
-    "eas-build-post-install": "npm run release"
+    "eject": "npx expo eject"
   },
   "dependencies": {
     "expo-cli": "4.10.0",


### PR DESCRIPTION
This change moves away from using the eas-build-post-install hook to perform the shadow-cljs release since that doesn't seem to work in the iOS build pipeline due to java not being present there.