### PR TITLE
Update react native to prevent Expo warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "expo-status-bar": "^1.4.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "react-native": "^0.69.5",
+        "react-native": "0.69.6",
         "react-native-web": "^0.18.9"
       },
       "devDependencies": {
@@ -15307,9 +15307,9 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-native": {
-      "version": "0.69.5",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.5.tgz",
-      "integrity": "sha512-4Psrj1nDMLQjBXVH8n3UikzOHQc8+sa6NbxZQR0XKtpx8uC3HiJBgX+/FIum/RWxfi5J/Dt/+A2gLGmq2Hps8g==",
+      "version": "0.69.6",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.6.tgz",
+      "integrity": "sha512-wwXpqM+12kdEYdBZCJUb5SBu95CzgejrwFeYJ78RzHZV/Sj6DBRekbsHGrDDsY4R25QXALQxy4DQYQCObVvWjA==",
       "dependencies": {
         "@jest/create-cache-key-function": "^27.0.1",
         "@react-native-community/cli": "^8.0.4",
@@ -15332,7 +15332,7 @@
         "mkdirp": "^0.5.1",
         "nullthrows": "^1.1.1",
         "pretty-format": "^26.5.2",
-        "promise": "^8.0.3",
+        "promise": "^8.2.0",
         "react-devtools-core": "4.24.0",
         "react-native-codegen": "^0.69.2",
         "react-native-gradle-plugin": "^0.0.7",
@@ -32752,9 +32752,9 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "react-native": {
-      "version": "0.69.5",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.5.tgz",
-      "integrity": "sha512-4Psrj1nDMLQjBXVH8n3UikzOHQc8+sa6NbxZQR0XKtpx8uC3HiJBgX+/FIum/RWxfi5J/Dt/+A2gLGmq2Hps8g==",
+      "version": "0.69.6",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.6.tgz",
+      "integrity": "sha512-wwXpqM+12kdEYdBZCJUb5SBu95CzgejrwFeYJ78RzHZV/Sj6DBRekbsHGrDDsY4R25QXALQxy4DQYQCObVvWjA==",
       "requires": {
         "@jest/create-cache-key-function": "^27.0.1",
         "@react-native-community/cli": "^8.0.4",
@@ -32777,7 +32777,7 @@
         "mkdirp": "^0.5.1",
         "nullthrows": "^1.1.1",
         "pretty-format": "^26.5.2",
-        "promise": "^8.0.3",
+        "promise": "^8.2.0",
         "react-devtools-core": "4.24.0",
         "react-native-codegen": "^0.69.2",
         "react-native-gradle-plugin": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "expo-status-bar": "^1.4.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-native": "^0.69.5",
+    "react-native": "0.69.6",
     "react-native-web": "^0.18.9"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes a warning that's shown when Expo starts:

```text
Some dependencies are incompatible with the installed expo version:
  react-native@0.69.5 - expected version: 0.69.6
Your project may not work correctly until you install the correct versions of the packages.
Install individual packages by running npx expo install react-native@0.69.6
```