### PR TITLE
React navigation

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {reagent.core/with-let clojure.core/let}}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ From there use your favorite editor and/or the prompt.
 1. Then **Run Build Task**. This will start Expo and the Metro
    builder. Wait for it to fire up Expo DevTools in your browser.
    1. Click **Run in web browser**
-1. When the app is running the Calva CLJS REPL can be used. Confirm this by evaluating something like: 
+1. When the app is running the Calva CLJS REPL can be used. Confirm this by evaluating something like:
    ``` clojure
    (js/alert "Hello world!")
    ```
@@ -66,14 +66,14 @@ Open Emacs and a bash shell:
    simulator, and transmit the bundled app. Be patient at this step as
    it can take many seconds to complete. When the app is finally
    running expo will display the message:
-   
+
        WebSocket connected!
        REPL init successful
 1. Once you see that the REPL is initalized, you can return to Emacs
    and confirm the REPL is connected and functional:
    ``` clojure
    cljs.user> (js/alert "hello world!")
-   ```   
+   ```
    Which should pop-up a modal alert in the simulator, confirming the
    app is running and the REPL is connected end to end.
 
@@ -85,14 +85,14 @@ Open Emacs and a bash shell:
    1. If you already have a project open, open the project in IntelliJ using _File | New | Project from existing sources..._ and indicating the `pom.xml` file.
    2. If you're at the welcome screen, press the "Open" button and navigate to the `pom.xml`.
 5. Ensure the project has an SDK configured using _File | Project Structure_, and checking under `Project`.
-7. The project comes with a REPL run configuration called "REPL". Run the REPL using the _Run | Run 'REPL'_ menu item, or the toolbar button. 
+7. The project comes with a REPL run configuration called "REPL". Run the REPL using the _Run | Run 'REPL'_ menu item, or the toolbar button.
 8. Run the commands in [Using ClojureScript REPL](#using-clojurescript-repl)
 
 ## Or the Command line
 ```sh
 $ npm i
 $ npx shadow-cljs watch app
-# wait for first compile to finish or expo gets confused 
+# wait for first compile to finish or expo gets confused
 # on another terminal tab/window:
 $ npm start
 ```
@@ -105,9 +105,9 @@ Note that you can also run the following instead of `npm start` to run the app i
    ```
    # same as npx expo start --web
    $ npm run web
-   
+
    # or
-   
+
    # same as npx expo start --web-only
    $ npm run web-only
    ```
@@ -191,6 +191,10 @@ See [the EAS Build docs](https://docs.expo.dev/build/introduction/) for more inf
 If you want to use EAS Build with a project not based on this template, see [this PR](https://github.com/PEZ/rn-rf-shadow/pull/24) for information about how your project can be set up to avoid an error during the build process.
 
 Note: The `eas-build-pre-install.sh` script makes EAS install Java in the MacOS environment when running a build for iOS. This ensures that shadow-cljs can be run in the EAS pipeline to build your ClojureScript code.
+
+## React Navigation included
+
+The app is setup to use [React Navigation](https://reactnavigation.org/). If you don't need that in your app, just remove it.
 
 ## "Known good" toolchain configurations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@react-navigation/native": "^6.1.6",
+        "@react-navigation/native-stack": "^6.9.12",
         "create-react-class": "^15.7.0",
         "expo": "^48.0.19",
         "expo-cli": "^6.3.8",
@@ -3720,6 +3721,17 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/@react-navigation/elements": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.17.tgz",
+      "integrity": "sha512-sui8AzHm6TxeEvWT/NEXlz3egYvCUog4tlXA4Xlb2Vxvy3purVXDq/XsM56lJl344U5Aj/jDzkVanOTMWyk4UA==",
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 3.0.0"
+      }
+    },
     "node_modules/@react-navigation/native": {
       "version": "6.1.6",
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.1.6.tgz",
@@ -3733,6 +3745,22 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@react-navigation/native-stack": {
+      "version": "6.9.12",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-6.9.12.tgz",
+      "integrity": "sha512-kS2zXCWP0Rgt7uWaCUKrRl7U2U1Gp19rM1kyRY2YzBPXhWGVPjQ2ygBp88CTQzjgy8M07H/79jvGiZ0mlEJI+g==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.17",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
       }
     },
     "node_modules/@react-navigation/native/node_modules/escape-string-regexp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@react-navigation/native": "^6.1.6",
         "create-react-class": "^15.7.0",
         "expo": "^48.0.19",
         "expo-cli": "^6.3.8",
@@ -12,6 +13,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-native": "^0.71.8",
+        "react-native-safe-area-context": "4.5.0",
+        "react-native-screens": "~3.20.0",
         "react-native-web": "^0.19.4"
       },
       "devDependencies": {
@@ -3684,6 +3687,72 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
       "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ=="
+    },
+    "node_modules/@react-navigation/core": {
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-6.4.8.tgz",
+      "integrity": "sha512-klZ9Mcf/P2j+5cHMoGyIeurEzyBM2Uq9+NoSFrF6sdV5iCWHLFhrCXuhbBiQ5wVLCKf4lavlkd/DDs47PXs9RQ==",
+      "dependencies": {
+        "@react-navigation/routers": "^6.1.8",
+        "escape-string-regexp": "^4.0.0",
+        "nanoid": "^3.1.23",
+        "query-string": "^7.1.3",
+        "react-is": "^16.13.0",
+        "use-latest-callback": "^0.1.5"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@react-navigation/core/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-navigation/core/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/@react-navigation/native": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.1.6.tgz",
+      "integrity": "sha512-14PmSy4JR8HHEk04QkxQ0ZLuqtiQfb4BV9kkMXD2/jI4TZ+yc43OnO6fQ2o9wm+Bq8pY3DxyerC2AjNUz+oH7Q==",
+      "dependencies": {
+        "@react-navigation/core": "^6.4.8",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^3.1.23"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@react-navigation/native/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-navigation/routers": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-6.1.8.tgz",
+      "integrity": "sha512-CEge+ZLhb1HBrSvv4RwOol7EKLW1QoqVIQlE9TN5MpxS/+VoQvP+cLbuz0Op53/iJfYhtXRFd1ZAd3RTRqto9w==",
+      "dependencies": {
+        "nanoid": "^3.1.23"
+      }
     },
     "node_modules/@segment/loosely-validate-event": {
       "version": "2.0.0",
@@ -8766,6 +8835,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -14054,6 +14131,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -14214,6 +14308,17 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-freeze": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.3.tgz",
+      "integrity": "sha512-ZnXwLQnGzrDpHBHiC56TXFXvmolPeMjTn1UOm610M4EXGzbEDR7oOIyS2ZiItgbs6eZc4oU/a0hpk8PrcKvv5g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -14284,6 +14389,28 @@
       "version": "0.71.18",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.18.tgz",
       "integrity": "sha512-7F6bD7B8Xsn3JllxcwHhFcsl9aHIig47+3eN4IHFNqfLhZr++3ElDrcqfMzugM+niWbaMi7bJ0kAkAL8eCpdWg=="
+    },
+    "node_modules/react-native-safe-area-context": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz",
+      "integrity": "sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-screens": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.20.0.tgz",
+      "integrity": "sha512-joWUKWAVHxymP3mL9gYApFHAsbd9L6ZcmpoZa6Sl3W/82bvvNVMqcfP7MeNqVCg73qZ8yL4fW+J/syusHleUgg==",
+      "dependencies": {
+        "react-freeze": "^1.0.0",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/react-native-web": {
       "version": "0.19.4",
@@ -15631,6 +15758,14 @@
         "node": "*"
       }
     },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -15846,6 +15981,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -16898,6 +17041,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/use-latest-callback": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.1.6.tgz",
+      "integrity": "sha512-VO/P91A/PmKH9bcN9a7O3duSuxe6M14ZoYXgA6a8dab8doWNdhiIHzEkX/jFeTTRBsX0Ubk6nG4q2NIjNsj+bg==",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -16987,6 +17138,11 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/warn-once": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
+      "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q=="
     },
     "node_modules/watchpack": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
     "create-react-class": "^15.7.0",
     "expo": "^48.0.19",
     "expo-cli": "^6.3.8",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "eas-build-post-install": "npx shadow-cljs release app"
   },
   "dependencies": {
+    "@react-navigation/native": "^6.1.6",
     "create-react-class": "^15.7.0",
     "expo": "^48.0.19",
     "expo-cli": "^6.3.8",
@@ -19,6 +20,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-native": "^0.71.8",
+    "react-native-safe-area-context": "4.5.0",
+    "react-native-screens": "~3.20.0",
     "react-native-web": "^0.19.4"
   },
   "devDependencies": {

--- a/src/main/example/app.cljs
+++ b/src/main/example/app.cljs
@@ -34,7 +34,7 @@
        "Tap me, I'll count"]]
      [:> rn/View {:style {:align-items :center}}
       [button {:on-press (fn []
-                           (rf/dispatch [:routing/navigate (.-navigation props) "About"]))}
+                           (-> props .-navigation (.navigate "About")))}
        "Tap me, I'll navigate"]]
      [:> rn/View
       [:> rn/View {:style {:flex-direction :row
@@ -80,9 +80,9 @@
 
 (defn root []
   ;; The save and restore of the navigation root state is for development time bliss
-  (r/with-let [!root-state (rf/subscribe [:routing/navigation-root-state])
+  (r/with-let [!root-state (rf/subscribe [:navigation/root-state])
                save-root-state! (fn [^js state]
-                                  (rf/dispatch [:routing/set-navigation-root-state state]))
+                                  (rf/dispatch [:navigation/set-root-state state]))
                add-listener! (fn [^js navigation-ref]
                                (when navigation-ref
                                  (.addListener navigation-ref "state" save-root-state!)))]
@@ -103,5 +103,4 @@
 
 (defn init []
   (rf/dispatch-sync [:initialize-db])
-  (rf/dispatch-sync [:routing/set-current-route "Home"])
   (start))

--- a/src/main/example/app.cljs
+++ b/src/main/example/app.cljs
@@ -7,44 +7,52 @@
             [re-frame.core :as rf]
             ["react-native" :as rn]
             [reagent.core :as r]
-            ["@react-navigation/native" :as rnn]))
+            ["@react-navigation/native" :as rnn]
+            ["@react-navigation/native-stack" :as rnn-stack]))
 
 (def shadow-splash (js/require "../assets/shadow-cljs.png"))
 (def cljs-splash (js/require "../assets/cljs.png"))
 
+(defonce Stack (rnn-stack/createNativeStackNavigator))
+
+(defn home []
+  (r/with-let [counter (rf/subscribe [:get-counter])
+               tap-enabled? (rf/subscribe [:counter-tappable?])]
+    [:> rn/View {:style {:flex 1
+                         :padding-vertical 50
+                         :justify-content :space-between
+                         :align-items :center
+                         :background-color :white}}
+     [:> rn/View {:style {:align-items :center}}
+      [:> rn/Text {:style {:font-weight   :bold
+                           :font-size     72
+                           :color         :blue
+                           :margin-bottom 20}} @counter]
+      [button {:on-press #(rf/dispatch [:inc-counter])
+               :disabled? (not @tap-enabled?)
+               :style {:background-color :blue}}
+       "Tap me, I'll count"]]
+     [:> rn/View
+      [:> rn/View {:style {:flex-direction :row
+                           :align-items :center
+                           :margin-bottom 20}}
+       [:> rn/Image {:style {:width  160
+                             :height 160}
+                     :source cljs-splash}]
+       [:> rn/Image {:style {:width  160
+                             :height 160}
+                     :source shadow-splash}]]
+      [:> rn/Text {:style {:font-weight :normal
+                           :font-size   15
+                           :color       :blue}}
+       "Using: shadow-cljs+expo+reagent+re-frame"]]
+     [:> StatusBar {:style "auto"}]]))
+
 (defn root []
-  (let [counter @(rf/subscribe [:get-counter])
-        tap-enabled? @(rf/subscribe [:counter-tappable?])]
-    [:> rnn/NavigationContainer
-     [:> rn/View {:style {:flex 1
-                          :padding-vertical 50
-                          :justify-content :space-between
-                          :align-items :center
-                          :background-color :white}}
-      [:> rn/View {:style {:align-items :center}}
-       [:> rn/Text {:style {:font-weight   :bold
-                            :font-size     72
-                            :color         :blue
-                            :margin-bottom 20}} counter]
-       [button {:on-press #(rf/dispatch [:inc-counter])
-                :disabled? (not tap-enabled?)
-                :style {:background-color :blue}}
-        "Tap me, I'll count"]]
-      [:> rn/View
-       [:> rn/View {:style {:flex-direction :row
-                            :align-items :center
-                            :margin-bottom 20}}
-        [:> rn/Image {:style {:width  160
-                              :height 160}
-                      :source cljs-splash}]
-        [:> rn/Image {:style {:width  160
-                              :height 160}
-                      :source shadow-splash}]]
-       [:> rn/Text {:style {:font-weight :normal
-                            :font-size   15
-                            :color       :blue}}
-        "Using: shadow-cljs+expo+reagent+re-frame"]]
-      [:> StatusBar {:style "auto"}]]]))
+  [:> rnn/NavigationContainer 
+   [:> Stack.Navigator
+    [:> Stack.Screen {:name "Home"
+                      :component #(r/as-element [home])}]]])
 
 (defn start
   {:dev/after-load true}

--- a/src/main/example/app.cljs
+++ b/src/main/example/app.cljs
@@ -66,7 +66,7 @@
                            :font-size     54
                            :color         :blue
                            :margin-bottom 20}}
-       "About Example App!"]
+       "About Example App"]
       [:> rn/Text {:style {:font-weight   :bold
                            :font-size     20
                            :color         :blue
@@ -79,14 +79,14 @@
      [:> StatusBar {:style "auto"}]]))
 
 (defn root []
-  ;; The save and restore of the navigation root state is for shadow-cljs hot reloading dev convenience
+  ;; The save and restore of the navigation root state is for development time bliss
   (r/with-let [!root-state (rf/subscribe [:routing/navigation-root-state])
-               save-root-state (fn [^js state]
-                                 (rf/dispatch [:routing/set-navigation-root-state state]))]
-    [:> rnn/NavigationContainer {:ref (fn [^js navigation-ref]
-                                        (when navigation-ref
-                                          (rf/dispatch [:routing/set-navigation-ref navigation-ref])
-                                          (.addListener navigation-ref "state" save-root-state)))
+               save-root-state! (fn [^js state]
+                                  (rf/dispatch [:routing/set-navigation-root-state state]))
+               add-listener! (fn [^js navigation-ref]
+                               (when navigation-ref
+                                 (.addListener navigation-ref "state" save-root-state!)))]
+    [:> rnn/NavigationContainer {:ref add-listener!
                                  :initialState (when @!root-state (-> @!root-state .-data .-state))}
      [:> Stack.Navigator
       [:> Stack.Screen {:name "Home"

--- a/src/main/example/app.cljs
+++ b/src/main/example/app.cljs
@@ -6,7 +6,8 @@
             ["expo-status-bar" :refer [StatusBar]]
             [re-frame.core :as rf]
             ["react-native" :as rn]
-            [reagent.core :as r]))
+            [reagent.core :as r]
+            ["@react-navigation/native" :as rnn]))
 
 (def shadow-splash (js/require "../assets/shadow-cljs.png"))
 (def cljs-splash (js/require "../assets/cljs.png"))
@@ -14,35 +15,36 @@
 (defn root []
   (let [counter @(rf/subscribe [:get-counter])
         tap-enabled? @(rf/subscribe [:counter-tappable?])]
-    [:> rn/View {:style {:flex 1
-                         :padding-vertical 50
-                         :justify-content :space-between
-                         :align-items :center
-                         :background-color :white}}
-     [:> rn/View {:style {:align-items :center}}
-      [:> rn/Text {:style {:font-weight   :bold
-                           :font-size     72
-                           :color         :blue
-                           :margin-bottom 20}} counter]
-      [button {:on-press #(rf/dispatch [:inc-counter])
-               :disabled? (not tap-enabled?)
-               :style {:background-color :blue}}
-       "Tap me, I'll count"]]
-     [:> rn/View
-      [:> rn/View {:style {:flex-direction :row
-                           :align-items :center
-                           :margin-bottom 20}}
-       [:> rn/Image {:style {:width  160
-                             :height 160}
-                     :source cljs-splash}]
-       [:> rn/Image {:style {:width  160
-                             :height 160}
-                     :source shadow-splash}]]
-      [:> rn/Text {:style {:font-weight :normal
-                           :font-size   15
-                           :color       :blue}}
-       "Using: shadow-cljs+expo+reagent+re-frame"]]
-     [:> StatusBar {:style "auto"}]]))
+    [:> rnn/NavigationContainer
+     [:> rn/View {:style {:flex 1
+                          :padding-vertical 50
+                          :justify-content :space-between
+                          :align-items :center
+                          :background-color :white}}
+      [:> rn/View {:style {:align-items :center}}
+       [:> rn/Text {:style {:font-weight   :bold
+                            :font-size     72
+                            :color         :blue
+                            :margin-bottom 20}} counter]
+       [button {:on-press #(rf/dispatch [:inc-counter])
+                :disabled? (not tap-enabled?)
+                :style {:background-color :blue}}
+        "Tap me, I'll count"]]
+      [:> rn/View
+       [:> rn/View {:style {:flex-direction :row
+                            :align-items :center
+                            :margin-bottom 20}}
+        [:> rn/Image {:style {:width  160
+                              :height 160}
+                      :source cljs-splash}]
+        [:> rn/Image {:style {:width  160
+                              :height 160}
+                      :source shadow-splash}]]
+       [:> rn/Text {:style {:font-weight :normal
+                            :font-size   15
+                            :color       :blue}}
+        "Using: shadow-cljs+expo+reagent+re-frame"]]
+      [:> StatusBar {:style "auto"}]]]))
 
 (defn start
   {:dev/after-load true}

--- a/src/main/example/app.cljs
+++ b/src/main/example/app.cljs
@@ -10,12 +10,12 @@
             ["@react-navigation/native" :as rnn]
             ["@react-navigation/native-stack" :as rnn-stack]))
 
-(def shadow-splash (js/require "../assets/shadow-cljs.png"))
-(def cljs-splash (js/require "../assets/cljs.png"))
+(defonce shadow-splash (js/require "../assets/shadow-cljs.png"))
+(defonce cljs-splash (js/require "../assets/cljs.png"))
 
 (defonce Stack (rnn-stack/createNativeStackNavigator))
 
-(defn home []
+(defn home [^js props]
   (r/with-let [counter (rf/subscribe [:get-counter])
                tap-enabled? (rf/subscribe [:counter-tappable?])]
     [:> rn/View {:style {:flex 1
@@ -32,6 +32,10 @@
                :disabled? (not @tap-enabled?)
                :style {:background-color :blue}}
        "Tap me, I'll count"]]
+     [:> rn/View {:style {:align-items :center}}
+      [button {:on-press (fn []
+                           (-> props .-navigation ( .navigate "About")))}
+       "Tap me, I'll navigate"]]
      [:> rn/View
       [:> rn/View {:style {:flex-direction :row
                            :align-items :center
@@ -48,11 +52,40 @@
        "Using: shadow-cljs+expo+reagent+re-frame"]]
      [:> StatusBar {:style "auto"}]]))
 
+(defn about []
+  (r/with-let [counter (rf/subscribe [:get-counter])]
+    [:> rn/View {:style {:flex 1
+                         :padding-vertical 50
+                         :padding-horizontal 20
+                         :justify-content :space-between
+                         :align-items :flex-start
+                         :background-color :white}}
+     [:> rn/View {:style {:align-items :flex-start}}
+      [:> rn/Text {:style {:font-weight   :bold
+                           :font-size     54
+                           :color         :blue
+                           :margin-bottom 20}}
+       "About Example App"]
+      [:> rn/Text {:style {:font-weight   :bold
+                           :font-size     20
+                           :color         :blue
+                           :margin-bottom 20}}
+       (str "Counter is at: " @counter)]
+      [:> rn/Text {:style {:font-weight :normal
+                           :font-size   15
+                           :color       :blue}}
+       "Built with React Native, Expo, Reagent, re-frame, and React Navigation"]]
+     [:> StatusBar {:style "auto"}]]))
+
 (defn root []
   [:> rnn/NavigationContainer 
    [:> Stack.Navigator
     [:> Stack.Screen {:name "Home"
-                      :component #(r/as-element [home])}]]])
+                      :component (fn [props] (r/as-element [home props]))
+                      :options {:title "Example App"}}]
+    [:> Stack.Screen {:name "About"
+                      :component (fn [props] (r/as-element [about props]))
+                      :options {:title "About"}}]]])
 
 (defn start
   {:dev/after-load true}

--- a/src/main/example/events.cljs
+++ b/src/main/example/events.cljs
@@ -1,15 +1,36 @@
 (ns example.events
   (:require
-   [re-frame.core :refer [reg-event-db]]
+   [re-frame.core :as rf]
    [example.db :as db :refer [app-db]]))
 
 
-(reg-event-db
+(rf/reg-event-db
  :initialize-db
  (fn [_ _]
    app-db))
 
-(reg-event-db
+(rf/reg-event-db
  :inc-counter
  (fn [db [_ _]]
    (update db :counter inc)))
+
+(rf/reg-fx
+ :routing/navigate
+ (fn [[navigation route]]
+   (.navigate navigation route)))
+
+(rf/reg-event-db
+ :routing/set-current-route
+ (fn [db [_ route]]
+   (assoc-in db [:routing :current-route] route)))
+
+(rf/reg-event-fx
+ :routing/navigate
+ (fn [_ [_ navigation route]]
+   {:dispatch [:routing/set-current-route route]
+    :routing/navigate [navigation route]}))
+
+(rf/reg-event-db
+ :routing/set-navigation-root-state
+ (fn [db [_ navigation-root-state]]
+   (assoc-in db [:routing :navigation-root-state] navigation-root-state)))

--- a/src/main/example/events.cljs
+++ b/src/main/example/events.cljs
@@ -14,23 +14,7 @@
  (fn [db [_ _]]
    (update db :counter inc)))
 
-(rf/reg-fx
- :routing/navigate
- (fn [[navigation route]]
-   (.navigate navigation route)))
-
 (rf/reg-event-db
- :routing/set-current-route
- (fn [db [_ route]]
-   (assoc-in db [:routing :current-route] route)))
-
-(rf/reg-event-fx
- :routing/navigate
- (fn [_ [_ navigation route]]
-   {:dispatch [:routing/set-current-route route]
-    :routing/navigate [navigation route]}))
-
-(rf/reg-event-db
- :routing/set-navigation-root-state
+ :navigation/set-root-state
  (fn [db [_ navigation-root-state]]
-   (assoc-in db [:routing :navigation-root-state] navigation-root-state)))
+   (assoc-in db [:navigation :root-state] navigation-root-state)))

--- a/src/main/example/subs.cljs
+++ b/src/main/example/subs.cljs
@@ -1,12 +1,22 @@
 (ns example.subs
-  (:require [re-frame.core :refer [reg-sub]]))
+  (:require [re-frame.core :as rf]))
 
-(reg-sub
+(rf/reg-sub
  :get-counter
  (fn [db _]
    (:counter db)))
 
-(reg-sub
+(rf/reg-sub
  :counter-tappable?
  (fn [db _]
    (:counter-tappable? db)))
+
+(rf/reg-sub
+ :routing/current-route
+ (fn [db _]
+   (get-in db [:routing :current-route])))
+
+(rf/reg-sub
+ :routing/navigation-root-state
+ (fn [db _]
+   (get-in db [:routing :navigation-root-state])))

--- a/src/main/example/subs.cljs
+++ b/src/main/example/subs.cljs
@@ -12,11 +12,6 @@
    (:counter-tappable? db)))
 
 (rf/reg-sub
- :routing/current-route
+ :navigation/root-state
  (fn [db _]
-   (get-in db [:routing :current-route])))
-
-(rf/reg-sub
- :routing/navigation-root-state
- (fn [db _]
-   (get-in db [:routing :navigation-root-state])))
+   (get-in db [:navigation :root-state])))

--- a/src/main/expo/root.cljs
+++ b/src/main/expo/root.cljs
@@ -30,5 +30,3 @@
                         body)))})]
 
         (expo/registerRootComponent Root)))))
-
-


### PR DESCRIPTION
Not sure about this. But how about we add React Navigation to the example app? Or will that be too framework-y, you think?

https://github.com/PEZ/rn-rf-shadow/assets/30010/b49b30c5-79f6-4780-b9bf-60649d515560

TODO:

* [x] Stop shadow-cljs reload from resetting the navigation stack