### PR TITLE
remove keep-awake

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -8,5 +8,4 @@
                       :init-fn          example.app/init
                       :output-dir       "app"
                       :compiler-options {:infer-externs :auto}
-                      :devtools         {:autoload true
-                                         :preloads [shadow.expo.keep-awake]}}}}
+                      :devtools         {:autoload true}}}}


### PR DESCRIPTION
When I run the repo as is I get Expo warnings about activateKeepAwake being deprecated. I removed this line from the shadow-cljs.edn file and experienced no negative effects with regards to the development experience, and I no longer get the warnings. This is not critical right now as it's just a warning but I imagine at some point it will be removed.